### PR TITLE
WIP: Begin review of install instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,7 +21,8 @@ You will need:
 1. Make sure your country is selected, and select **SMS** in the 'capabilities' choices.
 1. Pick a phone number by pressing **buy**. This is the number that all messages from your service will come from.
 1. Go back to the project dashboard by clicking in the top left where it says your project name.
-1. Make a note of your **Account SID**, **Auth Token** and **Phone number** in a text file or notes app for later use. That's it!
+1. Make a note of your **Account SID**, **Auth Token** and **Phone number** in a text file or notes app for later use.
+1. That's enough for testing, but when you're ready you will need to upgrade your account to be able to send messages using the **Upgrade project** button.
 
 ## Installing imok
 
@@ -55,21 +56,24 @@ You will then see a list of droplets in your interface. Give it a second while i
 Hopefully you're now logged into the remote server and the prompt says `root@HOSTNAME`. Type the following commands to set up the imok environment.
 
 ```shell
-# Install the postgres plugin
-sudo dokku plugin:install https://github.com/dokku/dokku-postgres.git
+# Set up the server
+apt update && apt upgrade # Select 'yes', then select the default for all options
+apt install pwgen
 
-# Create the app and database and link the two
+# Install needed plugins
+dokku plugin:install https://github.com/dokku/dokku-postgres.git
+
+# Create the app and database, and link the two
 dokku apps:create imok
 dokku postgres:create imok
 dokku postgres:link imok imok
+dokku config:set --no-restart imok DJANGO_SECRET_KEY=`pwgen 64 1`
 
-# Configure Twilio. Replace these values with the ones you created above.
+# Configure Twilio using the information you created above.
 dokku config:set --no-restart imok TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxx
 dokku config:set --no-restart imok TWILIO_AUTH_TOKEN=xxxxxxxxxxxxxxxxx
 # Make sure to add the single quotes around your phone number
 dokku config:set --no-restart imok TWILIO_FROM_NUMBER='+15005550000'
-
-dokku config:set --no-restart imok DJANGO_SECRET_KEY=`pwgen 64 1`
 
 # Turn off HTTP (optional)
 dokku proxy:ports-remove imok 80


### PR DESCRIPTION
OK started stepping through this. Have added Twilio instructions as that is quite a process.  I've moved a few things around and cleaned up a few missing steps but am currently stuck on line 79. I think missing steps are:

- [ ] Add Python buildpack
- [ ] Make it clearer why you would or wouldn't enable HTTP
- [ ] I think it should load in the imok library locally somehow without requiring you pushing it from a local git environment. Is it possible to pull from github?
- [ ] The last config:set needs to _not_ have `--no-restart`, or call explicitly
- [ ] BONUS: add instructions for adding letsencrypt if you use a domain name

```
root@goldman:~# dokku proxy:ports-remove imok 80
-----> Skipping DOKKU_PROXY_PORT_MAP, it is not set in the environment
 !     No web listeners specified for imok
root@goldman:~# dokku storage:mount imok /var/lib/dokku/data/storage:/code/static
root@goldman:~# dokku --rm run imok python manage.py createsuperuser
 !     App image (dokku/imok:latest) not found
 !     App image (dokku/imok:latest) not found
2021/03/29 14:25:18 exit status 1
Unable to find image 'python:latest' locally
latest: Pulling from library/python
8bf9c589d5f9: Pulling fs layer

<snip>

a9afc028cd66: Pull complete
Digest: sha256:8bd2e361ad8575ae80a6a3e556a524d44421cb5fa6b55ba6309be52efd08a578
Status: Downloaded newer image for python:latest
ERRO[0000] error waiting for container: context canceled
Error response from daemon: OCI runtime create failed: container_linux.go:367: starting container process caused: exec: "manage.py": executable file not found in $PATH: unknown
2021/03/29 14:25:55 exit status 1
root@goldman:~#
```