### PR TITLE
feat: notify admins on new releases

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,5 +4,10 @@
       "command": "python manage.py healthcheck",
       "schedule": "* * * * *"
     }
-  ]
+  ],
+    "scripts": {
+        "dokku": {
+            "postdeploy": "python manage.py release"
+        }
+    }
 }

--- a/application/contact_admins.py
+++ b/application/contact_admins.py
@@ -29,7 +29,7 @@ def telegram_admins(message):
     group = TelegramGroup.objects.filter(title=settings.TELEGRAM_GROUP).first()
     response = {
         "chat_id": group.chat_id,
-        "text": message
+        "text": message,
     }
     message_url = bot_url + 'sendMessage'
     r = requests.post(message_url, json=response)

--- a/application/management/commands/release.py
+++ b/application/management/commands/release.py
@@ -1,0 +1,32 @@
+import os
+
+from django.core.management.base import BaseCommand
+from application.contact_admins import notify_admins
+import requests
+
+
+def commit_message(rev):
+    r = requests.get(f"https://api.github.com/repos/geeksforsocialchange/imok/git/commits/{rev}")
+    if r.status_code == 404:
+        return "This commit was not found upstream"
+    else:
+        notes = f"Commit: {rev}\n" \
+               f"Committer: {r.json()['committer']['name']}\n" \
+               f"Message: {r.json()['message']}\n"\
+               f"URL: {r.json()['html_url']}"
+        tags = requests.get("https://api.github.com/repos/geeksforsocialchange/imok/tags")
+        releases = list(filter(lambda x: x['commit']['sha'] == rev, tags.json()))
+        if len(releases) == 1:
+            notes = f"{notes}\n" \
+                    f"Release: {releases[0]['name']}"
+        return notes
+
+
+def release():
+    git_rev = os.getenv("GIT_REV")
+    notify_admins("New deployment", f"A new version of imok was deployed\n{commit_message(git_rev)}")
+
+
+class Command(BaseCommand):
+    def handle(self, **options):
+        print(release())

--- a/features/release.feature
+++ b/features/release.feature
@@ -1,0 +1,14 @@
+Feature: Generate deployment notes
+    As an administrator
+    I want to know when the server is updated
+    So that I can be aware of unexpected side effects
+
+#    It's hard to test the sending of Telegram messages, but we can test the contents of the message
+    Scenario Outline:
+        Given git rev <rev>
+        Then the deployment message contains <string>
+        Examples:
+            | rev                                      | string                             |
+            | 4e9593f19345a7feec452a33a636a0b9b7a16a6a | Release: 0.1.0                     |
+            | 31fe54b4638e1f2fc45263aad90f999b0c9ef6aa | Init                               |
+            | abc123                                   | This commit was not found upstream |

--- a/features/steps/release_steps.py
+++ b/features/steps/release_steps.py
@@ -1,0 +1,12 @@
+from behave import given, when, then
+from application.management.commands.release import commit_message
+
+
+@given(u'git rev {rev}')
+def step_impl(context, rev):
+    context.deployMessage = commit_message(rev)
+
+
+@then(u'the deployment message contains {text}')
+def step_impl(context, text):
+    context.test.assertIn(text, context.deployMessage)


### PR DESCRIPTION
Notify admins that a new deployment was made to their server.  If the commit is in this GitHub repo then it will also include the latest git commit.

Example messages:

```
A new version of imok was deployed.
This commit was not found upstream
```

```
A new version of imok was deployed.
Commit: 18ede24c08f57e37ebb72fd1389232419fec56b9
Committer: WheresAlice
Message: feat: notify admins on new releases
```

I'm open to better messaging.

The only thing we know about the release is the git commit, and that git commit may or may not be in this repository.