### PR TITLE
chore: automatically raise a PR when translations are exported from POEditor

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+    - poeditor
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        destination_branch: "main"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        pr_title: "translation: sync translations from POEditor"
+        pr_body: "An automated PR from GitHub Actions"


### PR DESCRIPTION
This should automatically raise a PR whenever we press the export to GitHub button in POEditor.

It depends upon us turning on the option to export mo files alongside the po files.