### PR TITLE
fix: handle the telegram group not existing in some cases

### DIFF
--- a/application/commands.py
+++ b/application/commands.py
@@ -4,6 +4,9 @@ from django.utils.translation import gettext as _
 
 from .contact_admins import notify_admins
 from .telegram_botinfo import bot_link
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def handle_command(message, member):
@@ -31,8 +34,11 @@ def register(member):
     member.save()
     time = timezone.localtime().strftime('%X')
     date = timezone.localtime().strftime('%x')
-    notify_admins(f"🎉 {member.name} activated their account!",
-                  f"🎉 {member.name} ({member.phone_number}) successfully activated their account at {time} on {date}!")
+    try:
+        notify_admins(f"🎉 {member.name} activated their account!",
+                      f"🎉 {member.name} ({member.phone_number}) successfully activated their account at {time} on {date}!")
+    except:
+        logger.warning("Failed to notify admins of a new member")
     return info(member)
 
 

--- a/application/management/commands/release.py
+++ b/application/management/commands/release.py
@@ -3,28 +3,37 @@ import os
 from django.core.management.base import BaseCommand
 from application.contact_admins import notify_admins
 import requests
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def commit_message(rev):
-    r = requests.get(f"https://api.github.com/repos/geeksforsocialchange/imok/git/commits/{rev}")
-    if r.status_code == 404:
-        return "This commit was not found upstream"
-    else:
-        notes = f"Commit: {rev}\n" \
-               f"Committer: {r.json()['committer']['name']}\n" \
-               f"Message: {r.json()['message']}\n"\
-               f"URL: {r.json()['html_url']}"
-        tags = requests.get("https://api.github.com/repos/geeksforsocialchange/imok/tags")
-        releases = list(filter(lambda x: x['commit']['sha'] == rev, tags.json()))
-        if len(releases) == 1:
-            notes = f"{notes}\n" \
-                    f"Release: {releases[0]['name']}"
-        return notes
+    try:
+        r = requests.get(f"https://api.github.com/repos/geeksforsocialchange/imok/git/commits/{rev}")
+        if r.status_code == 404:
+            return "This commit was not found upstream"
+        else:
+            notes = f"Commit: {rev}\n" \
+                   f"Committer: {r.json()['committer']['name']}\n" \
+                   f"Message: {r.json()['message']}\n"\
+                   f"URL: {r.json()['html_url']}"
+            tags = requests.get("https://api.github.com/repos/geeksforsocialchange/imok/tags")
+            releases = list(filter(lambda x: x['commit']['sha'] == rev, tags.json()))
+            if len(releases) == 1:
+                notes = f"{notes}\n" \
+                        f"Release: {releases[0]['name']}"
+            return notes
+    except:
+        return "Failed to retrieve release details from GitHub"
 
 
 def release():
     git_rev = os.getenv("GIT_REV")
-    notify_admins("New deployment", f"A new version of imok was deployed\n{commit_message(git_rev)}")
+    try:
+        notify_admins("New deployment", f"A new version of imok was deployed\n{commit_message(git_rev)}")
+    except:
+        logger.warning("Failed to notify admins of a new release")
 
 
 class Command(BaseCommand):

--- a/application/templates/varz.html
+++ b/application/templates/varz.html
@@ -2,12 +2,14 @@
     <tr>
         <th>Key</th>
         <th>Value</th>
+        <th>Solution</th>
         <th>Valid</th>
     </tr>
     {% for v in varz %}
     <tr>
         <td>{{v.key}}</td>
         <td>{{v.value}}</td>
+        <td>{{v.solution}}</td>
         <td style='background-color: #{{ v.validation|yesno:"66c2a5,fc8d62,8da0cb" }}'>{{ v.validation|yesno:"✔,✘," }}</td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
* Show the chat_id in varz and a suggested fix if it's non-numeric
* log a warn if we fail to notify the admin group of a release
* log a warn if we fail to notify the admin group of a new member

Continue to let Telegram retry sending if we fail on an SOS.