### PR TITLE
chore: upgrade Django

### DIFF
--- a/imok/settings.py
+++ b/imok/settings.py
@@ -137,8 +137,12 @@ if os.environ.get('GITHUB_WORKFLOW'):
 
 # Use environment variables for the database in Dokku, and use whitenoise and prod settings
 if 'DATABASE_URL' in env:
-    ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', 'localhost').split(',')
+    hosts = os.environ.get('ALLOWED_HOSTS', 'localhost').split(',')
+    ALLOWED_HOSTS = hosts
     ALLOWED_HOSTS.append(socket.getaddrinfo(socket.gethostname(), 'http')[0][4][0])
+    CSRF_TRUSTED_ORIGINS = []
+    for host in hosts:
+        CSRF_TRUSTED_ORIGINS.append(f"https://{host}")
     DATABASES["default"] = env.db("DATABASE_URL")  # noqa F405
     DATABASES["default"]["ATOMIC_REQUESTS"] = True  # noqa F405
     DATABASES["default"]["CONN_MAX_AGE"] = env.int("CONN_MAX_AGE", default=60)  # noqa F405

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=3.0,<4.0
+Django>=4.0,<5.0
 psycopg2-binary>=2.8
 django-phonenumber-field[phonenumberslite]
 twilio


### PR DESCRIPTION
Minor code change to handle the new CSRF origin protection, but otherwise seems a straight replacement

This will break if you are trying to load the admin login screen from anywhere other than the configured domain, but otherwise no noticeable changes